### PR TITLE
Fix Dockerfile binary location issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,6 @@ ADD ./ $GOPATH/src/$GO_PACKAGE_PATH
 RUN make go-dependencies && go mod tidy && go mod vendor
 ENV GO111MODULE=auto
 RUN make build
-ADD build/_output/bin/jenkins-operator /usr/local/bin/jenkins-operator
+RUN cp build/_output/bin/jenkins-operator /usr/local/bin/jenkins-operator
 
 CMD [ "/usr/local/bin/jenkins-operator" ]


### PR DESCRIPTION
This description also covers for last 3 commits before this 
- Changed all instances of `jenkinsci/kubernetes-operator` to `redhat-developer/jenkins-operator` for vendoring which makes sense for the repo
- Allow for execution of jenkins-operator binary from main Dockerfile at `/` path