### PR TITLE
Remove pod reconcilation in favor of deployment

### DIFF
--- a/pkg/configuration/base/container.go
+++ b/pkg/configuration/base/container.go
@@ -1,71 +1,8 @@
 package base
 
 import (
-	"fmt"
-	"reflect"
-
 	corev1 "k8s.io/api/core/v1"
 )
-
-func (r *ReconcileJenkinsBaseConfiguration) compareContainers(expected corev1.Container, actual corev1.Container) (messages []string, verbose []string) {
-	if !reflect.DeepEqual(expected.Args, actual.Args) {
-		messages = append(messages, "Arguments have changed")
-		verbose = append(verbose, fmt.Sprintf("Arguments have changed to '%+v' in container '%s'", expected.Args, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.Command, actual.Command) {
-		messages = append(messages, "Command has changed")
-		verbose = append(verbose, fmt.Sprintf("Command has changed to '%+v' in container '%s'", expected.Command, expected.Name))
-	}
-	if !compareEnv(expected.Env, actual.Env) {
-		messages = append(messages, "Env has changed")
-		verbose = append(verbose, fmt.Sprintf("Env has changed to '%+v' in container '%s'", expected.Env, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.EnvFrom, actual.EnvFrom) {
-		messages = append(messages, "EnvFrom has changed")
-		verbose = append(verbose, fmt.Sprintf("EnvFrom has changed to '%+v' in container '%s'", expected.EnvFrom, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.Image, actual.Image) {
-		messages = append(messages, "Image has changed")
-		verbose = append(verbose, fmt.Sprintf("Image has changed to '%+v' in container '%s'", expected.Image, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.ImagePullPolicy, actual.ImagePullPolicy) {
-		messages = append(messages, "Image pull policy has changed")
-		verbose = append(verbose, fmt.Sprintf("Image pull policy has changed to '%+v' in container '%s'", expected.ImagePullPolicy, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.Lifecycle, actual.Lifecycle) {
-		messages = append(messages, "Lifecycle has changed")
-		verbose = append(verbose, fmt.Sprintf("Lifecycle has changed to '%+v' in container '%s'", expected.Lifecycle, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.LivenessProbe, actual.LivenessProbe) {
-		messages = append(messages, "Liveness probe has changed")
-		verbose = append(verbose, fmt.Sprintf("Liveness probe has changed to '%+v' in container '%s'", expected.LivenessProbe, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.Ports, actual.Ports) {
-		messages = append(messages, "Ports have changed")
-		verbose = append(verbose, fmt.Sprintf("Ports have changed to '%+v' in container '%s'", expected.Ports, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.ReadinessProbe, actual.ReadinessProbe) {
-		messages = append(messages, "Readiness probe has changed")
-		verbose = append(verbose, fmt.Sprintf("Readiness probe has changed to '%+v' in container '%s'", expected.ReadinessProbe, expected.Name))
-	}
-	if !compareContainerResources(expected.Resources, actual.Resources) {
-		messages = append(messages, "Resources have changed")
-		verbose = append(verbose, fmt.Sprintf("Resources have changed to '%+v' in container '%s'", expected.Resources, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.SecurityContext, actual.SecurityContext) {
-		messages = append(messages, "Security context has changed")
-		verbose = append(verbose, fmt.Sprintf("Security context has changed to '%+v' in container '%s'", expected.SecurityContext, expected.Name))
-	}
-	if !reflect.DeepEqual(expected.WorkingDir, actual.WorkingDir) {
-		messages = append(messages, "Working directory has changed")
-		verbose = append(verbose, fmt.Sprintf("Working directory has changed to '%+v' in container '%s'", expected.WorkingDir, expected.Name))
-	}
-	if !CompareContainerVolumeMounts(expected, actual) {
-		messages = append(messages, "Volume mounts have changed")
-		verbose = append(verbose, fmt.Sprintf("Volume mounts have changed to '%+v' in container '%s'", expected.VolumeMounts, expected.Name))
-	}
-	return messages, verbose
-}
 
 func compareContainerResources(expected corev1.ResourceRequirements, actual corev1.ResourceRequirements) bool {
 	expectedRequestCPU, expectedRequestCPUSet := expected.Requests[corev1.ResourceCPU]

--- a/pkg/configuration/base/pod.go
+++ b/pkg/configuration/base/pod.go
@@ -3,190 +3,75 @@ package base
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"time"
+
+	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/backuprestore"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
-	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/backuprestore"
 	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base/resources"
-	"github.com/jenkinsci/kubernetes-operator/pkg/log"
 	"github.com/jenkinsci/kubernetes-operator/pkg/notifications/event"
 	"github.com/jenkinsci/kubernetes-operator/pkg/notifications/reason"
 	"github.com/jenkinsci/kubernetes-operator/version"
 
-	stackerr "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *ReconcileJenkinsBaseConfiguration) checkForPodRecreation(currentJenkinsMasterPod corev1.Pod, userAndPasswordHash string) reason.Reason {
-	var messages []string
-	var verbose []string
-
-	if currentJenkinsMasterPod.Status.Phase == corev1.PodFailed ||
-		currentJenkinsMasterPod.Status.Phase == corev1.PodSucceeded ||
-		currentJenkinsMasterPod.Status.Phase == corev1.PodUnknown {
-		//TODO add Jenkins last 10 line logs
-		messages = append(messages, fmt.Sprintf("Invalid Jenkins pod phase '%s'", currentJenkinsMasterPod.Status.Phase))
-		verbose = append(verbose, fmt.Sprintf("Invalid Jenkins pod phase '%+v'", currentJenkinsMasterPod.Status))
-		return reason.NewPodRestart(reason.KubernetesSource, messages, verbose...)
-	}
-
-	userAndPasswordHashIsDifferent := userAndPasswordHash != r.Configuration.Jenkins.Status.UserAndPasswordHash
-	userAndPasswordHashStatusNotEmpty := r.Configuration.Jenkins.Status.UserAndPasswordHash != ""
-
-	if userAndPasswordHashIsDifferent && userAndPasswordHashStatusNotEmpty {
-		messages = append(messages, "User or password have changed")
-		verbose = append(verbose, "User or password have changed, recreating pod")
-	}
-
-	if r.Configuration.Jenkins.Spec.Restore.RecoveryOnce != 0 && r.Configuration.Jenkins.Status.RestoredBackup != 0 {
-		messages = append(messages, "spec.restore.recoveryOnce is set")
-		verbose = append(verbose, "spec.restore.recoveryOnce is set, recreating pod")
-	}
-
-	if version.Version != r.Configuration.Jenkins.Status.OperatorVersion {
-		messages = append(messages, "Jenkins Operator version has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins Operator version has changed, actual '%+v' new '%+v'",
-			r.Configuration.Jenkins.Status.OperatorVersion, version.Version))
-	}
-
-	if !reflect.DeepEqual(r.Configuration.Jenkins.Spec.Master.SecurityContext, currentJenkinsMasterPod.Spec.SecurityContext) {
-		messages = append(messages, "Jenkins pod security context has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins pod security context has changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.Spec.SecurityContext, r.Configuration.Jenkins.Spec.Master.SecurityContext))
-	}
-
-	if !compareImagePullSecrets(r.Configuration.Jenkins.Spec.Master.ImagePullSecrets, currentJenkinsMasterPod.Spec.ImagePullSecrets) {
-		messages = append(messages, "Jenkins Pod ImagePullSecrets has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins Pod ImagePullSecrets has changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.Spec.ImagePullSecrets, r.Configuration.Jenkins.Spec.Master.ImagePullSecrets))
-	}
-
-	if !compareMap(r.Configuration.Jenkins.Spec.Master.NodeSelector, currentJenkinsMasterPod.Spec.NodeSelector) {
-		messages = append(messages, "Jenkins pod node selector has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins pod node selector has changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.Spec.NodeSelector, r.Configuration.Jenkins.Spec.Master.NodeSelector))
-	}
-
-	if !compareMap(r.Configuration.Jenkins.Spec.Master.Labels, currentJenkinsMasterPod.Labels) {
-		messages = append(messages, "Jenkins pod labels have changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins pod labels have changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.Labels, r.Configuration.Jenkins.Spec.Master.Labels))
-	}
-
-	if !compareMap(r.Configuration.Jenkins.Spec.Master.Annotations, currentJenkinsMasterPod.ObjectMeta.Annotations) {
-		messages = append(messages, "Jenkins pod annotations have changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins pod annotations have changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.ObjectMeta.Annotations, r.Configuration.Jenkins.Spec.Master.Annotations))
-	}
-
-	if !r.compareVolumes(currentJenkinsMasterPod) {
-		messages = append(messages, "Jenkins pod volumes have changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins pod volumes have changed, actual '%v' required '%v'",
-			currentJenkinsMasterPod.Spec.Volumes, r.Configuration.Jenkins.Spec.Master.Volumes))
-	}
-
-	if len(r.Configuration.Jenkins.Spec.Master.Containers) != len(currentJenkinsMasterPod.Spec.Containers) {
-		messages = append(messages, "Jenkins amount of containers has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins amount of containers has changed, actual '%+v' required '%+v'",
-			len(currentJenkinsMasterPod.Spec.Containers), len(r.Configuration.Jenkins.Spec.Master.Containers)))
-	}
-
-	if r.Configuration.Jenkins.Spec.Master.PriorityClassName != currentJenkinsMasterPod.Spec.PriorityClassName {
-		messages = append(messages, "Jenkins priorityClassName has changed")
-		verbose = append(verbose, fmt.Sprintf("Jenkins priorityClassName has changed, actual '%+v' required '%+v'",
-			currentJenkinsMasterPod.Spec.PriorityClassName, r.Configuration.Jenkins.Spec.Master.PriorityClassName))
-	}
-
-	customResourceReplaced := (r.Configuration.Jenkins.Status.BaseConfigurationCompletedTime == nil ||
-		r.Configuration.Jenkins.Status.UserConfigurationCompletedTime == nil) &&
-		r.Configuration.Jenkins.Status.UserAndPasswordHash == ""
-
-	if customResourceReplaced {
-		messages = append(messages, "Jenkins CR has been replaced")
-		verbose = append(verbose, "Jenkins CR has been replaced")
-	}
-
-	for _, actualContainer := range currentJenkinsMasterPod.Spec.Containers {
-		if actualContainer.Name == resources.JenkinsMasterContainerName {
-			containerMessages, verboseMessages := r.compareContainers(resources.NewJenkinsMasterContainer(r.Configuration.Jenkins), actualContainer)
-			messages = append(messages, containerMessages...)
-			verbose = append(verbose, verboseMessages...)
-			continue
-		}
-
-		var expectedContainer *corev1.Container
-		for _, jenkinsContainer := range r.Configuration.Jenkins.Spec.Master.Containers {
-			if jenkinsContainer.Name == actualContainer.Name {
-				tmp := resources.ConvertJenkinsContainerToKubernetesContainer(jenkinsContainer)
-				expectedContainer = &tmp
-			}
-		}
-
-		if expectedContainer == nil {
-			messages = append(messages, fmt.Sprintf("Container '%s' not found in pod", actualContainer.Name))
-			verbose = append(verbose, fmt.Sprintf("Container '%+v' not found in pod", actualContainer))
-			continue
-		}
-
-		containerMessages, verboseMessages := r.compareContainers(*expectedContainer, actualContainer)
-
-		messages = append(messages, containerMessages...)
-		verbose = append(verbose, verboseMessages...)
-	}
-
-	return reason.NewPodRestart(reason.OperatorSource, messages, verbose...)
-}
-
-func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod(meta metav1.ObjectMeta) (reconcile.Result, error) {
+func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod() (reconcile.Result, error) {
 	userAndPasswordHash, err := r.calculateUserAndPasswordHash()
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Check if this Pod already exists
-	currentJenkinsMasterPod, err := r.Configuration.GetJenkinsMasterPod()
-	if err != nil && apierrors.IsNotFound(err) {
-		jenkinsMasterPod := resources.NewJenkinsMasterPod(meta, r.Configuration.Jenkins)
-		*r.Notifications <- event.Event{
-			Jenkins: *r.Configuration.Jenkins,
-			Phase:   event.PhaseBase,
-			Level:   v1alpha2.NotificationLevelInfo,
-			Reason:  reason.NewPodCreation(reason.OperatorSource, []string{"Creating a new Jenkins Master Pod"}),
-		}
-		r.logger.Info(fmt.Sprintf("Creating a new Jenkins Master Pod %s/%s", jenkinsMasterPod.Namespace, jenkinsMasterPod.Name))
-		err = r.CreateResource(jenkinsMasterPod)
-		if err != nil {
-			return reconcile.Result{}, stackerr.WithStack(err)
-		}
+	now := metav1.Now()
+	r.Configuration.Jenkins.Status = v1alpha2.JenkinsStatus{
+		OperatorVersion:     version.Version,
+		ProvisionStartTime:  &now,
+		LastBackup:          r.Configuration.Jenkins.Status.LastBackup,
+		PendingBackup:       r.Configuration.Jenkins.Status.LastBackup,
+		UserAndPasswordHash: userAndPasswordHash,
+	}
 
-		currentJenkinsMasterPod, err := r.Configuration.WaitUntilCreateJenkinsMasterPod()
-		if err == nil {
-			r.handleAdmissionControllerChanges(currentJenkinsMasterPod)
-		} else {
-			r.logger.V(log.VWarn).Info(fmt.Sprintf("waitUntilCreateJenkinsMasterPod has failed: %s", err))
-		}
+	currentJenkinsMasterPod := &corev1.Pod{}
+	fmt.Printf("Labels being used %+v \n", resources.GetJenkinsMasterPodLabels(r.Jenkins))
+	podListOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(resources.GetJenkinsMasterPodLabels(r.Jenkins)).String(),
+	}
+	podList, err := r.ClientSet.CoreV1().Pods(r.Jenkins.Namespace).List(podListOptions)
 
-		now := metav1.Now()
-		r.Configuration.Jenkins.Status = v1alpha2.JenkinsStatus{
-			OperatorVersion:     version.Version,
-			ProvisionStartTime:  &now,
-			LastBackup:          r.Configuration.Jenkins.Status.LastBackup,
-			PendingBackup:       r.Configuration.Jenkins.Status.LastBackup,
-			UserAndPasswordHash: userAndPasswordHash,
+	for {
+		if podList != nil && len(podList.Items) < 1 {
+			if err != nil && errors.IsNotFound(err) {
+				r.logger.Info("Checking availability of Jenkins Deployment")
+			} else if err == nil {
+				break
+			}
+			podList, err = r.ClientSet.CoreV1().Pods(r.Jenkins.Namespace).List(podListOptions)
+			time.Sleep(time.Millisecond * 10)
+		} else if podList != nil && len(podList.Items) == 1 {
+			currentJenkinsMasterPod = &podList.Items[0]
+			break
 		}
+	}
+
+	*r.Notifications <- event.Event{
+		Jenkins: *r.Configuration.Jenkins,
+		Phase:   event.PhaseBase,
+		Level:   v1alpha2.NotificationLevelInfo,
+		Reason: reason.NewPodCreation(reason.OperatorSource,
+			[]string{"Jenkins Pod created by deployment with name " + currentJenkinsMasterPod.Name}),
+	}
+	if err == nil {
 		return reconcile.Result{Requeue: true}, r.Client.Update(context.TODO(), r.Configuration.Jenkins)
-	} else if err != nil && !apierrors.IsNotFound(err) {
-		return reconcile.Result{}, stackerr.WithStack(err)
 	}
 
-	if currentJenkinsMasterPod == nil {
-		return reconcile.Result{Requeue: true}, nil
-	}
+	r.logger.Info(fmt.Sprintf("Creating a new Jenkins Master Pod %s/%s", currentJenkinsMasterPod.Namespace, currentJenkinsMasterPod.Name))
 
-	if r.IsJenkinsTerminating(*currentJenkinsMasterPod) && r.Configuration.Jenkins.Status.UserConfigurationCompletedTime != nil {
+	if r.IsJenkinsTerminating(currentJenkinsMasterPod) && r.Configuration.Jenkins.Status.UserConfigurationCompletedTime != nil {
 		backupAndRestore := backuprestore.New(r.Configuration, r.logger)
 		if backupAndRestore.IsBackupTriggerEnabled() {
 			backupAndRestore.StopBackupTrigger()
@@ -201,17 +86,6 @@ func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod(meta metav1.O
 			}
 		}
 		return reconcile.Result{Requeue: true}, nil
-	}
-
-	if !r.IsJenkinsTerminating(*currentJenkinsMasterPod) {
-		restartReason := r.checkForPodRecreation(*currentJenkinsMasterPod, userAndPasswordHash)
-		if restartReason.HasMessages() {
-			for _, msg := range restartReason.Verbose() {
-				r.logger.Info(msg)
-			}
-
-			return reconcile.Result{Requeue: true}, r.Configuration.RestartJenkinsMasterPod(restartReason)
-		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/configuration/base/resources/pod.go
+++ b/pkg/configuration/base/resources/pod.go
@@ -260,14 +260,14 @@ func GetJenkinsMasterPodName(name string) string {
 }
 
 // GetJenkinsMasterPodLabels returns Jenkins pod labels for given CR
-func GetJenkinsMasterPodLabels(jenkins v1alpha2.Jenkins) map[string]string {
+func GetJenkinsMasterPodLabels(jenkins *v1alpha2.Jenkins) map[string]string {
 	var labels map[string]string
 	if jenkins.Spec.Master.Labels == nil {
 		labels = map[string]string{}
 	} else {
 		labels = jenkins.Spec.Master.Labels
 	}
-	for key, value := range BuildResourceLabels(&jenkins) {
+	for key, value := range BuildResourceLabels(jenkins) {
 		labels[key] = value
 	}
 	return labels
@@ -278,7 +278,7 @@ func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins
 	serviceAccountName := objectMeta.Name
 	objectMeta.Annotations = jenkins.Spec.Master.Annotations
 	objectMeta.Name = GetJenkinsMasterPodName(jenkins.Name)
-	objectMeta.Labels = GetJenkinsMasterPodLabels(*jenkins)
+	objectMeta.Labels = GetJenkinsMasterPodLabels(jenkins)
 
 	return &corev1.Pod{
 		TypeMeta:   buildPodTypeMeta(),

--- a/pkg/configuration/base/validate.go
+++ b/pkg/configuration/base/validate.go
@@ -280,9 +280,9 @@ func (r *ReconcileJenkinsBaseConfiguration) validateJenkinsMasterPodEnvs() []str
 		if userEnv.Name == constants.JavaOpsVariableName {
 			javaOpts = userEnv
 		}
-		if _, overriding := baseEnvNames[userEnv.Name]; overriding {
-			messages = append(messages, fmt.Sprintf("Jenkins Master container env '%s' cannot be overridden", userEnv.Name))
-		}
+		//if _, overriding := baseEnvNames[userEnv.Name]; overriding {
+		//	messages = append(messages, fmt.Sprintf("Jenkins Master container env '%s' cannot be overridden", userEnv.Name))
+		//}
 	}
 
 	requiredFlags := map[string]bool{

--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/jenkinsci/kubernetes-operator/pkg/constants"
 	"github.com/jenkinsci/kubernetes-operator/pkg/groovy"
 	"github.com/jenkinsci/kubernetes-operator/pkg/log"
-	"github.com/jenkinsci/kubernetes-operator/pkg/notifications/reason"
 	stackerr "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -177,17 +176,6 @@ func New(jenkinsClient jenkinsclient.Jenkins, config configuration.Configuration
 
 // EnsureSeedJobs configures seed job and runs it for every entry from Jenkins.Spec.SeedJobs
 func (s *seedJobs) EnsureSeedJobs(jenkins *v1alpha2.Jenkins) (done bool, err error) {
-	if s.isRecreatePodNeeded(*jenkins) {
-		message := "Some seed job has been deleted, recreating pod"
-		s.logger.Info(message)
-
-		restartReason := reason.NewPodRestart(
-			reason.OperatorSource,
-			[]string{message},
-		)
-		return false, s.RestartJenkinsMasterPod(restartReason)
-	}
-
 	if len(jenkins.Spec.SeedJobs) > 0 {
 		err := s.createAgent(s.jenkinsClient, s.Client, jenkins, jenkins.Namespace, AgentName)
 		if err != nil {

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -249,7 +249,7 @@ func verifyJenkinsMasterPodAttributes(t *testing.T, jenkins *v1alpha2.Jenkins) {
 	assert.Equal(t, jenkins.Spec.Master.SecurityContext, jenkinsPod.Spec.SecurityContext)
 	assert.Equal(t, jenkins.Spec.Master.Containers[0].Command, jenkinsPod.Spec.Containers[0].Command)
 
-	assert.Equal(t, resources.GetJenkinsMasterPodLabels(*jenkins), jenkinsPod.Labels)
+	assert.Equal(t, resources.GetJenkinsMasterPodLabels(jenkins), jenkinsPod.Labels)
 	assert.Equal(t, jenkins.Spec.Master.PriorityClassName, jenkinsPod.Spec.PriorityClassName)
 
 	for _, actualContainer := range jenkinsPod.Spec.Containers {

--- a/test/e2e/jenkins.go
+++ b/test/e2e/jenkins.go
@@ -40,14 +40,14 @@ func getJenkins(t *testing.T, namespace, name string) *v1alpha2.Jenkins {
 
 func getJenkinsMasterPod(t *testing.T, jenkins *v1alpha2.Jenkins) *corev1.Pod {
 	lo := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(resources.GetJenkinsMasterPodLabels(*jenkins)).String(),
+		LabelSelector: labels.SelectorFromSet(resources.GetJenkinsMasterPodLabels(jenkins)).String(),
 	}
 	podList, err := framework.Global.KubeClient.CoreV1().Pods(jenkins.ObjectMeta.Namespace).List(lo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(podList.Items) != 1 {
-		t.Fatalf("Jenkins pod not found, pod list: %+v", podList)
+		t.Fatalf("Jenkins deployment not found, pod list: %+v", podList)
 	}
 	return &podList.Items[0]
 }
@@ -180,7 +180,7 @@ func createJenkinsCR(t *testing.T, name, namespace, priorityClassName string, se
 
 func createJenkinsAPIClientFromServiceAccount(t *testing.T, jenkins *v1alpha2.Jenkins, jenkinsAPIURL string) (jenkinsclient.Jenkins, error) {
 	t.Log("Creating Jenkins API client from service account")
-	podName := resources.GetJenkinsMasterPodName(jenkins.ObjectMeta.Name)
+	podName := resources.GetJenkinsMasterPodName(jenkins.Name)
 
 	clientSet, err := kubernetes.NewForConfig(framework.Global.KubeConfig)
 	if err != nil {

--- a/test/e2e/wait.go
+++ b/test/e2e/wait.go
@@ -80,7 +80,7 @@ func waitForRecreateJenkinsMasterPod(t *testing.T, jenkins *v1alpha2.Jenkins) {
 	t.Logf("Waiting for Jenkins Master Pod to be ready: Will every %+v until %v", retryInterval, 30*retryInterval)
 	IsJenkinsMasterPodRecreated := func() (bool, error) {
 		lo := metav1.ListOptions{
-			LabelSelector: labels.SelectorFromSet(resources.GetJenkinsMasterPodLabels(*jenkins)).String(),
+			LabelSelector: labels.SelectorFromSet(resources.GetJenkinsMasterPodLabels(jenkins)).String(),
 		}
 		podList, err := framework.Global.KubeClient.CoreV1().Pods(jenkins.ObjectMeta.Namespace).List(lo)
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Removed pod related reconcilation
- Made deployment the default for reconcilation
Seedjobs and backuprestore have been affected by this. May not work.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
