### PR TITLE
fix rbac

### DIFF
--- a/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
+++ b/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
@@ -69,7 +69,7 @@ spec:
           -Djenkins.install.runSetupWizard=false -Djava.awt.headless=true
           -Dhudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID=true
           -Dcasc.reload.token=$(POD_NAME)
-      image: 'quay.io/repository/openshift/origin-jenkins:4.5'
+      image: 'quay.io/openshift/origin-jenkins:4.5'
       imagePullPolicy: Always
       livenessProbe:
         httpGet:

--- a/pkg/configuration/base/resources/rbac.go
+++ b/pkg/configuration/base/resources/rbac.go
@@ -62,7 +62,6 @@ func NewRoleBinding(name, namespace, serviceAccountName string, roleRef v1.RoleR
 // NewDefaultPolicyRules sets the default policy rules
 func NewDefaultPolicyRules() []v1.PolicyRule {
 	var rules []v1.PolicyRule
-	readOnly := []string{getVerb, listVerb, watchVerb}
 	Default := []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb}
 	create := []string{createVerb}
 	watch := []string{watchVerb}
@@ -70,14 +69,14 @@ func NewDefaultPolicyRules() []v1.PolicyRule {
 	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "pods/portforward", create))
 	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "pods", Default))
 	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "pods/exec", Default))
-	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "configmaps", readOnly))
-	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "pods/log", readOnly))
-	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "secrets", readOnly))
+	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "configmaps", Default))
+	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "pods/log", Default))
+	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "secrets", Default))
 	rules = append(rules, NewPolicyRule(EmptyAPIGroup, "events", watch))
 
-	rules = append(rules, NewOpenShiftPolicyRule(OpenshiftAPIGroup, "imagestreams", readOnly))
-	rules = append(rules, NewOpenShiftPolicyRule(BuildAPIGroup, "buildconfigs", readOnly))
-	rules = append(rules, NewOpenShiftPolicyRule(BuildAPIGroup, "builds", readOnly))
+	rules = append(rules, NewOpenShiftPolicyRule(OpenshiftAPIGroup, "imagestreams", Default))
+	rules = append(rules, NewOpenShiftPolicyRule(BuildAPIGroup, "buildconfigs", Default))
+	rules = append(rules, NewOpenShiftPolicyRule(BuildAPIGroup, "builds", Default))
 
 	return rules
 }


### PR DESCRIPTION
Related to 
Uploading finished
Error from server (Forbidden): buildconfigs.build.openshift.io "openshift-jee-sample-docker" is forbidden: User "system:serviceaccount:jenkins-test:jenkins-operator-example" cannot create resource "buildconfigs/instantiatebinary" in API group "build.openshift.io" in the namespace "jenkins-test"
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // timeout
[Pipeline] echo
in catch block
[Pipeline] echo
Caught: hudson.AbortException: script returned exit code 1 

The jenkins service account should be able to create object in the namespace
