### PR TITLE
Externalise images for jenkinsimage-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+login.sh
 .DS_Store
 config.json
 kubeconfig

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/operator-framework/operator-lib/status"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/bundle/manifests/jenkins-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jenkins-operator.clusterserviceversion.yaml
@@ -124,7 +124,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.0.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: jenkins-operator.v0.6.0
+  name: jenkins-operator.v0.7.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -234,7 +234,7 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                image: quay.io/redhat-developer/openshift-jenkins-operator:0.6.0-8e0d2878
+                image: quay.io/redhat-developer/openshift-jenkins-operator:0.7.0-d9d1755f
                 name: manager
                 resources:
                   limits:
@@ -302,4 +302,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.6.0
+  version: 0.7.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/redhat-developer/openshift-jenkins-operator
-  newTag: 0.6.0-8e0d2878
+  newTag: 0.7.0-d9d1755f

--- a/pkg/configuration/base/resources/builder.go
+++ b/pkg/configuration/base/resources/builder.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"os"
 
 	jenkinsv1alpha2 "github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
@@ -13,17 +14,17 @@ import (
 const (
 	NameWithSuffixFormat         = "%s-%s"
 	PluginDefinitionFormat       = "%s:%s"
-	BuilderDockerfileArg         = "--dockerfile=/workspace/dockerfile/Dockerfile"
+	BuilderDockerfileArg         = "--dockerfile=/dockerfile/Dockerfile"
 	BuilderContextDirArg         = "--context=dir://workspace/"
 	BuilderNoPushArg             = "--no-push"
 	BuilderDestinationArg        = "--destination"
-	BuilderDigestFileArg         = "--image-name-with-digest-file=/dev/termination-log"
+	BuilderDigestFileArg         = "--digest-file=/dev/termination-log"
 	BuilderReproducibleArg       = "--reproducible"
 	BuilderSuffix                = "builder"
 	DockerfileStorageSuffix      = "dockerfile-storage"
 	DockerSecretSuffix           = "docker-secret"
 	DockerfileNameSuffix         = "dockerfile"
-	JenkinsImageBuilderImage     = "gcr.io/kaniko-project/executor:debug"
+	JenkinsImageBuilderImage     = "quay.io/redhat-developer/openshift-jenkins-image-builder:v1.3.0"
 	JenkinsImageBuilderName      = "jenkins-image-builder"
 	JenkinsImageDefaultBaseImage = "jenkins/jenkins:lts"
 	DefaultImageRegistry         = "image-registry.openshift-image-registry.svc:5000"
@@ -63,7 +64,7 @@ func getBuilderPod(name string, cr *jenkinsv1alpha2.JenkinsImage, builderPodArgs
 			Containers: []corev1.Container{
 				{
 					Name:         JenkinsImageBuilderName,
-					Image:        JenkinsImageBuilderImage,
+					Image:        getJenkinsImageBuilderImage(),
 					Args:         builderPodArgs,
 					VolumeMounts: volumeMounts,
 				},
@@ -71,6 +72,16 @@ func getBuilderPod(name string, cr *jenkinsv1alpha2.JenkinsImage, builderPodArgs
 			Volumes: volumes,
 		},
 	}
+}
+
+const JenkinsImageBuilderEnv = "JENKINS_IMAGE_BUILDER_NAME"
+
+func getJenkinsImageBuilderImage() string {
+	image := os.Getenv(JenkinsImageBuilderEnv)
+	if len(image) != 0 {
+		return image
+	}
+	return JenkinsImageBuilderImage
 }
 
 // GetDestinationRepository returns the destination repository matching To.Repository/To.Name:To.Tag or default to
@@ -202,7 +213,7 @@ func getVolumesMounts(cr *jenkinsv1alpha2.JenkinsImage, client client.Client) []
 	logger.Info(fmt.Sprintf("Volument mount for %s and mountPath : %s created", name, mountPath))
 
 	name = fmt.Sprintf(NameWithSuffixFormat, cr.Name, DockerfileNameSuffix)
-	mountPath = "/workspace/dockerfile"
+	mountPath = "/dockerfile"
 	config := corev1.VolumeMount{
 		Name:      name,
 		MountPath: mountPath,

--- a/scripts/commons.mk
+++ b/scripts/commons.mk
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.6.0
+VERSION ?= 0.7.0
 GIT_COMMIT_ID ?= $(shell git rev-parse --short HEAD)
 # Default bundle image tag
 BUNDLE_IMG ?= quay.io/redhat-developer/openshift-jenkins-operator-bundle:$(VERSION)


### PR DESCRIPTION
- use JENKINS_IMAGE_BUILDER_NAME to externalize jenkinsimage-builder
- pushed the kaniko image in quay
- change the digestfile attribute
- use a separate /dockerfile/Dockerfile directory/file
