### PR TITLE
Ensure clusterrole binding to edit is created

### DIFF
--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -24,7 +24,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/operator-framework/operator-lib/status"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/rbac/v1"
+	v1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
+++ b/config/samples/openshift_jenkins_v1alpha2_jenkins_cr.yaml
@@ -24,9 +24,9 @@ spec:
       - name: KUBERNETES_TRUST_CERTIFICATES
         value: 'true'
       - name: JENKINS_SERVICE_NAME
-        value: jenkins-operator-http-jenkins
+        value: jenkins-jenkins
       - name: JNLP_SERVICE_NAME
-        value: jenkins-operator-jnlp-jenkins
+        value: jenkins-jenkins-jnlp
       - name: JENKINS_UC_INSECURE
         value: 'false'
       - name: JENKINS_HOME

--- a/config/samples/simple_jenkins_v1alpha2_jenkins.yaml
+++ b/config/samples/simple_jenkins_v1alpha2_jenkins.yaml
@@ -2,5 +2,4 @@ apiVersion: jenkins.io/v1alpha2
 kind: Jenkins
 metadata:
   name: simple
-spec:
-  forceBasePluginsInstall: true
+

--- a/controllers/jenkins_controller_test.go
+++ b/controllers/jenkins_controller_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base"
+
 	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base/resources"
 	"github.com/jenkinsci/kubernetes-operator/pkg/constants"
@@ -20,12 +22,26 @@ import (
 
 const (
 	// Name                  = "test-image"
-	JenkinsName      = "test-jenkins"
-	JenkinsNamespace = "default"
+	JenkinsName        = "test-jenkins"
+	MinimalJenkinsName = "minimal-jenkins"
+	JenkinsNamespace   = "default"
 )
 
 var _ = Describe("Jenkins controller", func() {
 	Logf("Starting")
+
+	Context("When Creating a Minimal Jenkins Instance", func() {
+		ctx := context.Background()
+		jenkins := GetMinimalJenkinsTestInstance(MinimalJenkinsName, JenkinsNamespace)
+		It("Deployment Should Be Created", func() {
+			CreateEditClusterRole(ctx)
+			ByCreatingJenkinsSuccesfully(ctx, jenkins)
+			ByCheckingThatJenkinsExists(ctx, jenkins)
+			ByCheckingThatDefaultRoleBindingIsCreated(ctx, jenkins)
+			ByCheckingThatTheDeploymentExists(ctx, jenkins)
+		})
+	})
+
 	Context("When Creating a Jenkins CR", func() {
 		ctx := context.Background()
 		jenkins := GetJenkinsTestInstance(JenkinsName, JenkinsNamespace)
@@ -49,6 +65,17 @@ var _ = Describe("Jenkins controller", func() {
 		})
 	})
 })
+
+func CreateEditClusterRole(ctx context.Context) {
+	editClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      base.EditClusterRole,
+			Namespace: JenkinsNamespace,
+		},
+		Rules: resources.NewDefaultPolicyRules(),
+	}
+	Expect(k8sClient.Create(ctx, editClusterRole)).Should(Succeed())
+}
 
 func ByCheckingThatDeploymentImageIs(ctx context.Context, jenkins *v1alpha2.Jenkins) {
 	By("By checking that the Jenkins exists")
@@ -86,6 +113,23 @@ func ByCheckingThatJenkinsExists(ctx context.Context, jenkins *v1alpha2.Jenkins)
 	Eventually(actual, timeout, interval).Should(Equal(created))
 }
 
+func ByCheckingThatDefaultRoleBindingIsCreated(ctx context.Context, jenkins *v1alpha2.Jenkins) {
+	By("By checking that default RoleBinding is created")
+	expected := &rbacv1.RoleBinding{}
+	roleRef := rbacv1.RoleRef{Name: "edit", Kind: "ClusterRole", APIGroup: base.AuthorizationAPIGroup}
+	expectedName := resources.GetExtraRoleBindingName(jenkins, roleRef)
+	key := types.NamespacedName{Namespace: jenkins.Namespace, Name: expectedName}
+	actual := func() (*rbacv1.RoleBinding, error) {
+		err := k8sClient.Get(ctx, key, expected)
+		if err != nil {
+			return nil, err
+		}
+		return expected, nil
+	}
+	Eventually(actual, timeout, interval).ShouldNot(BeNil())
+	Eventually(actual, timeout, interval).Should(Equal(expected))
+}
+
 func ByCheckingThatTheDeploymentExists(ctx context.Context, jenkins *v1alpha2.Jenkins) {
 	By("By checking that the Pod exists")
 	expected := &appsv1.Deployment{}
@@ -106,6 +150,7 @@ func ByCreatingJenkinsSuccesfully(ctx context.Context, jenkins *v1alpha2.Jenkins
 	By("By creating a new Jenkins")
 	Expect(k8sClient.Create(ctx, jenkins)).Should(Succeed())
 }
+
 func GetJenkinsTestInstance(name string, namespace string) *v1alpha2.Jenkins {
 	// TODO fix e2e to use deployment instead of pod
 	annotations := map[string]string{"test": "label"}
@@ -128,6 +173,17 @@ func GetJenkinsTestInstance(name string, namespace string) *v1alpha2.Jenkins {
 			},
 			Service: getJenkinsServices(),
 			Roles:   getJenkinsRoles(name),
+		},
+	}
+	return jenkins
+}
+
+func GetMinimalJenkinsTestInstance(name string, namespace string) *v1alpha2.Jenkins {
+	jenkins := &v1alpha2.Jenkins{
+		TypeMeta: v1alpha2.JenkinsTypeMeta(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 	return jenkins

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca
+	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-lib v0.1.0
 	github.com/operator-framework/operator-sdk v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func fatal(err error, debug bool) {
 }
 
 func printInfo() {
-	version.Version = "0.6.0-rc1"
+	version.Version = "0.7.0"
 	setupLog.Info(fmt.Sprintf("Version: %s", version.Version))
 	file, _ := filepath.Abs(os.Args[0])
 	setupLog.Info(fmt.Sprintf("MD5 checkcsum: %s", md5sum(file)))

--- a/pkg/configuration/base/reconcile_test.go
+++ b/pkg/configuration/base/reconcile_test.go
@@ -617,18 +617,21 @@ func TestEnsureExtraRBAC(t *testing.T) {
 				Roles: []rbacv1.RoleRef{},
 			},
 		}
+		jenkins.Status = &v1alpha2.JenkinsStatus{
+			Spec: jenkins.Spec.DeepCopy(),
+		}
 		config := configuration.Configuration{
 			Client:  fakeClient,
 			Jenkins: jenkins,
 			Scheme:  scheme.Scheme,
 		}
-		reconciler := New(config, client.JenkinsAPIConnectionSettings{})
+		reconcilier := New(config, client.JenkinsAPIConnectionSettings{})
 		metaObject := resources.NewResourceObjectMeta(jenkins)
 
 		// when
-		err = reconciler.createRBAC(metaObject)
+		err = reconcilier.createRBAC(jenkins)
 		assert.NoError(t, err)
-		err = reconciler.ensureExtraRBAC(metaObject)
+		err = reconcilier.ensureExtraRBACArePresent()
 		assert.NoError(t, err)
 
 		// then
@@ -659,6 +662,9 @@ func TestEnsureExtraRBAC(t *testing.T) {
 				},
 			},
 		}
+		jenkins.Status = &v1alpha2.JenkinsStatus{
+			Spec: jenkins.Spec.DeepCopy(),
+		}
 		config := configuration.Configuration{
 			Client:  fakeClient,
 			Jenkins: jenkins,
@@ -668,9 +674,9 @@ func TestEnsureExtraRBAC(t *testing.T) {
 		metaObject := resources.NewResourceObjectMeta(jenkins)
 
 		// when
-		err = reconciler.createRBAC(metaObject)
+		err = reconciler.createRBAC(jenkins)
 		assert.NoError(t, err)
-		err = reconciler.ensureExtraRBAC(metaObject)
+		err = reconciler.ensureExtraRBACArePresent()
 		assert.NoError(t, err)
 
 		// then
@@ -706,6 +712,9 @@ func TestEnsureExtraRBAC(t *testing.T) {
 				},
 			},
 		}
+		jenkins.Status = &v1alpha2.JenkinsStatus{
+			Spec: jenkins.Spec.DeepCopy(),
+		}
 		config := configuration.Configuration{
 			Client:  fakeClient,
 			Jenkins: jenkins,
@@ -715,9 +724,9 @@ func TestEnsureExtraRBAC(t *testing.T) {
 		metaObject := resources.NewResourceObjectMeta(jenkins)
 
 		// when
-		err = reconciler.createRBAC(metaObject)
+		err = reconciler.createRBAC(jenkins)
 		assert.NoError(t, err)
-		err = reconciler.ensureExtraRBAC(metaObject)
+		err = reconciler.ensureExtraRBACArePresent()
 		assert.NoError(t, err)
 
 		// then
@@ -754,6 +763,9 @@ func TestEnsureExtraRBAC(t *testing.T) {
 				},
 			},
 		}
+		jenkins.Status = &v1alpha2.JenkinsStatus{
+			Spec: jenkins.Spec.DeepCopy(),
+		}
 		config := configuration.Configuration{
 			Client:  fakeClient,
 			Jenkins: jenkins,
@@ -763,16 +775,16 @@ func TestEnsureExtraRBAC(t *testing.T) {
 		metaObject := resources.NewResourceObjectMeta(jenkins)
 
 		// when
-		roleBindingSkipMe := resources.NewRoleBinding("skip-me", namespace, metaObject.Name, rbacv1.RoleRef{
+		roleBindingSkipMe := resources.NewRoleBinding(jenkins, rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     clusterRoleKind,
 			Name:     "edit",
 		})
 		err = reconciler.CreateOrUpdateResource(roleBindingSkipMe)
 		assert.NoError(t, err)
-		err = reconciler.createRBAC(metaObject)
+		err = reconciler.createRBAC(jenkins)
 		assert.NoError(t, err)
-		err = reconciler.ensureExtraRBAC(metaObject)
+		err = reconciler.ensureExtraRBACArePresent()
 		assert.NoError(t, err)
 		jenkins.Spec.Roles = []rbacv1.RoleRef{
 			{
@@ -781,7 +793,7 @@ func TestEnsureExtraRBAC(t *testing.T) {
 				Name:     "admin",
 			},
 		}
-		err = reconciler.ensureExtraRBAC(metaObject)
+		err = reconciler.ensureExtraRBACArePresent()
 		assert.NoError(t, err)
 
 		// then

--- a/pkg/configuration/base/resources/meta.go
+++ b/pkg/configuration/base/resources/meta.go
@@ -1,17 +1,16 @@
 package resources
 
 import (
-	"context"
 	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	"github.com/jenkinsci/kubernetes-operator/pkg/constants"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// TODO Remove this meta object stuff and use Jenkins instead
 // NewResourceObjectMeta builds ObjectMeta for all Kubernetes resources created by operator
 func NewResourceObjectMeta(jenkins *v1alpha2.Jenkins) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
@@ -19,6 +18,17 @@ func NewResourceObjectMeta(jenkins *v1alpha2.Jenkins) metav1.ObjectMeta {
 		Namespace: jenkins.ObjectMeta.Namespace,
 		Labels:    BuildResourceLabels(jenkins),
 	}
+}
+
+func GetExtraRoleBindingName(jenkins *v1alpha2.Jenkins, roleRef rbacv1.RoleRef) string {
+	serviceAccountName := NewResourceObjectMeta(jenkins).Name
+	var typeName string
+	if roleRef.Kind == "ClusterRole" {
+		typeName = "cr"
+	} else {
+		typeName = "r"
+	}
+	return fmt.Sprintf("%s-%s-%s", serviceAccountName, typeName, roleRef.Name)
 }
 
 // BuildResourceLabels returns labels for all Kubernetes resources created by operator
@@ -29,83 +39,7 @@ func BuildResourceLabels(jenkins *v1alpha2.Jenkins) map[string]string {
 	}
 }
 
-// BuildLabelsForWatchedResources returns labels for Kubernetes resources which operator want to watch
-// resources with that labels should not be deleted after Jenkins CR deletion, to prevent this situation don't set
-// any owner
-func BuildLabelsForWatchedResources(crName string) map[string]string {
-	return map[string]string{
-		constants.LabelAppKey:       constants.LabelAppValue,
-		constants.LabelJenkinsCRKey: crName,
-		constants.LabelWatchKey:     constants.LabelWatchValue,
-	}
-}
-
 // GetResourceName returns name of Kubernetes resource base on Jenkins CR
 func GetResourceName(jenkins *v1alpha2.Jenkins) string {
-	return fmt.Sprintf("%s-%s", constants.LabelAppValue, jenkins.ObjectMeta.Name)
-}
-
-// VerifyIfLabelsAreSet check is selected labels are set for specific resource
-func VerifyIfLabelsAreSet(object metav1.Object, requiredLabels map[string]string) bool {
-	for key, value := range requiredLabels {
-		if object.GetLabels()[key] != value {
-			return false
-		}
-	}
-
-	return true
-}
-
-// Add labels to watched secrets
-func AddLabelToWatchedSecrets(crName, secretName, namespace string, k8sClient k8s.Client) error {
-	labelsForWatchedResources := BuildLabelsForWatchedResources(crName)
-
-	if len(secretName) > 0 {
-		secret := &corev1.Secret{}
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
-		if err != nil {
-			return err
-		}
-
-		if !VerifyIfLabelsAreSet(secret, labelsForWatchedResources) {
-			if len(secret.ObjectMeta.Labels) == 0 {
-				secret.ObjectMeta.Labels = map[string]string{}
-			}
-			for key, value := range labelsForWatchedResources {
-				secret.ObjectMeta.Labels[key] = value
-			}
-
-			if err = k8sClient.Update(context.TODO(), secret); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// Adds label to watched configmaps
-func AddLabelToWatchedCMs(crName, namespace string, k8sClient k8s.Client, configmaps []v1alpha2.ConfigMapRef) error {
-	labelsForWatchedResources := BuildLabelsForWatchedResources(crName)
-
-	for _, configMapRef := range configmaps {
-		configMap := &corev1.ConfigMap{}
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: configMapRef.Name, Namespace: namespace}, configMap)
-		if err != nil {
-			return err
-		}
-
-		if !VerifyIfLabelsAreSet(configMap, labelsForWatchedResources) {
-			if len(configMap.ObjectMeta.Labels) == 0 {
-				configMap.ObjectMeta.Labels = map[string]string{}
-			}
-			for key, value := range labelsForWatchedResources {
-				configMap.ObjectMeta.Labels[key] = value
-			}
-
-			if err = k8sClient.Update(context.TODO(), configMap); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return fmt.Sprintf("%s-%s", constants.LabelAppValue, jenkins.Name)
 }

--- a/pkg/configuration/base/resources/pod.go
+++ b/pkg/configuration/base/resources/pod.go
@@ -99,6 +99,15 @@ func GetJenkinsMasterContainerBaseEnvs(jenkins *v1alpha2.Jenkins) []corev1.EnvVa
 			Value: "true",
 		},
 		{
+			Name:  "JENKINS_SERVICE_NAME",
+			Value: GetJenkinsHTTPServiceName(jenkins),
+		},
+		{
+			Name:  "JNLP_SERVICE_NAME",
+			Value: GetJenkinsJNLPServiceName(jenkins),
+		},
+
+		{
 			Name:  "OPENSHIFT_ENABLE_REDIRECT_PROMPT",
 			Value: "true",
 		},

--- a/pkg/configuration/base/resources/rbac.go
+++ b/pkg/configuration/base/resources/rbac.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,7 +26,8 @@ const (
 )
 
 // NewRole returns rbac role for jenkins master
-func NewRole(meta metav1.ObjectMeta) *v1.Role {
+func NewRole(jenkins *v1alpha2.Jenkins) *v1.Role {
+	meta := NewResourceObjectMeta(jenkins)
 	rules := NewDefaultPolicyRules()
 	return &v1.Role{
 		TypeMeta: metav1.TypeMeta{
@@ -38,14 +40,18 @@ func NewRole(meta metav1.ObjectMeta) *v1.Role {
 }
 
 // NewRoleBinding returns rbac role binding for jenkins master
-func NewRoleBinding(name, namespace, serviceAccountName string, roleRef v1.RoleRef) *v1.RoleBinding {
+func NewRoleBinding(jenkins *v1alpha2.Jenkins, roleRef v1.RoleRef) *v1.RoleBinding {
+	resourceWithPrefix := NewResourceObjectMeta(jenkins)
+	roleBindingName := GetExtraRoleBindingName(jenkins, roleRef)
+	serviceAccountName := resourceWithPrefix.Name
+	namespace := jenkins.Namespace
 	return &v1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RoleBinding",
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      roleBindingName,
 			Namespace: namespace,
 		},
 		RoleRef: roleRef,

--- a/pkg/configuration/base/resources/resource.go
+++ b/pkg/configuration/base/resources/resource.go
@@ -5,6 +5,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	DefaultCPURequest    = "50m"
+	DefaultMemoryRequest = "50Mi"
+	DefaultCPULimit      = "100m"
+	DefaultMemoryLimit   = "100Mi"
+)
+
 func NewResourceRequirements(cpuRequest, memoryRequest, cpuLimit, memoryLimit string) corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -16,4 +23,8 @@ func NewResourceRequirements(cpuRequest, memoryRequest, cpuLimit, memoryLimit st
 			corev1.ResourceMemory: resource.MustParse(memoryLimit),
 		},
 	}
+}
+
+func DefaultResourceRequirement() corev1.ResourceRequirements {
+	return NewResourceRequirements(DefaultCPURequest, DefaultMemoryRequest, DefaultCPULimit, DefaultMemoryLimit)
 }

--- a/pkg/configuration/base/serviceaccount.go
+++ b/pkg/configuration/base/serviceaccount.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
+
 	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base/resources"
 	"github.com/jenkinsci/kubernetes-operator/pkg/log"
 	stackerr "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -18,7 +19,8 @@ const (
 	oauthAnnotationPattern = "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"%s\"}}"
 )
 
-func (r *JenkinsBaseConfigurationReconciler) createServiceAccount(meta metav1.ObjectMeta) error {
+func (r *JenkinsBaseConfigurationReconciler) createServiceAccount(jenkins *v1alpha2.Jenkins) error {
+	meta := resources.NewResourceObjectMeta(jenkins)
 	serviceAccount := &corev1.ServiceAccount{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: meta.Name, Namespace: meta.Namespace}, serviceAccount)
 	annotations := r.Configuration.Jenkins.Spec.ServiceAccount.Annotations


### PR DESCRIPTION
Ensure that rolebinding pointing to clusterrole `edit` is correctly created.
If the `jenkins.Spec.Roles` is nil, it is created , but if it is an empty slice/ emty array, it is not.
